### PR TITLE
Fix build on GNU/Linux: CheckOSError() is for Windows

### DIFF
--- a/MD_Tools.pas
+++ b/MD_Tools.pas
@@ -247,8 +247,10 @@ procedure CheckPCSCError(ErrorCode: Cardinal);
 begin
   if ErrorCode >= $80000000 then
     raise Exception.Create(PCSCErrorToString(ErrorCode))
+{$IFDEF WINDOWS}
   else
     CheckOSError(ErrorCode);
+{$ENDIF}
 end;
 
 end.


### PR DESCRIPTION
CheckOSError() is a Windows function.

Compilation on GNU/Linux fails with:
MD_Tools.pas(252,5) Error: Identifier not found "CheckOSError"