### PR TITLE
SCardTransmit: set the receiving buffer size

### DIFF
--- a/MD_PCSCRaw.pas
+++ b/MD_PCSCRaw.pas
@@ -281,7 +281,11 @@ end;
 function TPCSCRaw.SCardTransmit(hCard: THandle; PioSendPci: PSCardIoRequest; SendBuffer: Pointer; SizeSendBuffer: Cardinal; PioRecvPci: PSCardIoRequest; RecvBuffer: Pointer;
   var SizeRecvBuffer: Cardinal): Cardinal;
 begin
-  if FValid and Assigned(FSCardTransmit) then Result := FSCardTransmit(hCard, PioSendPci, SendBuffer, SizeSendBuffer, PioRecvPci, RecvBuffer, SizeRecvBuffer)
+  if FValid and Assigned(FSCardTransmit) then
+    begin
+      Result := FSCardTransmit(hCard, PioSendPci, SendBuffer, SizeSendBuffer, PioRecvPci, RecvBuffer, SizeRecvBuffer)
+      SetLength(RecvBuffer, SizeRecvBuffer);
+    end
   else Result := SCARD_E_UNSUPPORTED_FEATURE;
 end;
 


### PR DESCRIPTION
Truncate the receiving buffer RecvBuffer to the size received in
SizeRecvBuffer.

I have NOT tested this patch.
But I needed to use something like this in my sample code at https://ludovicrousseau.blogspot.com/2020/05/pcsc-sample-in-free-pascal-lazarus.html